### PR TITLE
feat: integrate QtJambi into devcontainer and maven, enable java spell checking

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,6 +4,13 @@ ARG USERNAME=morphin
 ARG USER_ID=1000
 ARG USER_GID=${USER_ID}
 
+# Parameters for Qt installation (needs to be the same as QtJambi's)
+# Alter QT_VERSION to install different version of Qt
+ARG QT_VERSION=6.8.1
+ARG QT_INSTALL_DIR=/opt/Qt
+
+ENV LD_LIBRARY_PATH=/opt/Qt/${QT_VERSION}/gcc_64/lib
+
 # Setup user and enable passwordless sudo
 RUN groupadd --gid ${USER_GID} ${USERNAME} && \
     useradd --uid ${USER_ID} --gid ${USER_GID} -m ${USERNAME} && \
@@ -20,6 +27,16 @@ RUN dnf -y install java-21-openjdk java-21-openjdk-src maven
 # Install Python3 and gcc for PyQt6
 RUN dnf -y install python3 python3-pip python3-devel python-pip-wheel gcc
 
+# Install Another Qt installer (aqt)
+RUN pip install -U pip && \
+    pip install aqtinstall
+
+# Install Qt in default install location QtJambi will look in
+RUN aqt install-qt --outputdir ${QT_INSTALL_DIR} linux desktop ${QT_VERSION} linux_gcc_64
+
+# Uninstall Another Qt installer (aqt)
+RUN pip uninstall -y aqtinstall
+
 USER ${USERNAME}
 
-RUN pip install PyQt6
+# RUN pip install PyQt6

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive",
+    "ltex.enabled": [
+        "bibtex",
+        "context",
+        "context.tex",
+        "html",
+        "latex",
+        "markdown",
+        "mdx",
+        "typst",
+        "org",
+        "quarto",
+        "restructuredtext",
+        "rsweave",
+        "java"
+    ]
+}

--- a/raytracer/pom.xml
+++ b/raytracer/pom.xml
@@ -11,6 +11,7 @@
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
+        <qtjambi.version>6.8.1</qtjambi.version>
     </properties>
     <dependencies>
         <dependency>
@@ -18,6 +19,26 @@
             <artifactId>junit-jupiter</artifactId>
             <version>5.8.1</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.qtjambi</groupId>
+            <artifactId>qtjambi</artifactId>
+            <version>${qtjambi.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.qtjambi</groupId>
+            <artifactId>qtjambi-native-linux-x64</artifactId>
+            <version>${qtjambi.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.qtjambi</groupId>
+            <artifactId>qtjambi-uitools</artifactId>
+            <version>${qtjambi.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.qtjambi</groupId>
+            <artifactId>qtjambi-uitools-native-linux-x64</artifactId>
+            <version>${qtjambi.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
# Description

This switches the Devcontainer from pyqt6 to QtJambi, includes QtJambi in Maven and enables spell checking for Java files.

## ⁉️ Type Of Change

- [x] ⚙️ New feature (non-breaking change which adds functionality).
- [ ] 🪛 Bug fix (non-breaking change).
- [ ] ⚠️ Breaking change (fix of feature that would cause existing functionality to not work as expected).
- [ ] ✏️ This change requires a documentation update.

## 🧪 How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## ✅ Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
